### PR TITLE
動画読込中の追加ロードを防止。

### DIFF
--- a/src/coffee/list.coffee
+++ b/src/coffee/list.coffee
@@ -22,6 +22,7 @@ $ ->
         limit: ""
       count: ""
       sortMode: false
+      videoLoading: false
     created: () ->
       @query.sid = "omedeto"
       @reloadList()
@@ -112,6 +113,10 @@ $ ->
 
       # サムネイルをクリック
       showVideo: (id) ->
+        if @videoLoading
+          alert "別の動画を現在読込中です。表示されるまでお待ち下さい。"
+          return
+        @videoLoading = true
         @getVideo id
         .then (result) =>
           if result.vid
@@ -131,13 +136,16 @@ $ ->
 
               @video = result
               @countView result
+              @videoLoading = false
               return
             .catch (err) ->
               console.log err
+              @videoLoading = false
               return
           return
         .catch (err) ->
           console.log err
+          @videoLoading = false
           return
         return
 


### PR DESCRIPTION
@chae0629 
/list でサムネイルをたくさんタップすると、たくさん読み込みが発生してしまいます。
とりいそぎ、既存の読み込みが終わるまでタップしてもアラートを表示するようにしました。

確認お願いします。