### PR TITLE
Fix/video encode on old ffmpeg

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "mongodb": "2.1.11",
     "morgan": "~1.3.0",
     "nodemon": "1.8.0",
+    "node-ffprobe": "1.2.2",
     "primus": "5.0.1",
     "primus-emitter": "3.1.1",
     "primus-rooms": "3.4.0",

--- a/src/config.coffee
+++ b/src/config.coffee
@@ -19,3 +19,6 @@ exports.config =
     general:
       user: "user"
       password: "password"
+  video_compression:
+    bitrate: 800000  # kb/s
+    target_width: 640  # 

--- a/src/routes/files.coffee
+++ b/src/routes/files.coffee
@@ -71,17 +71,18 @@ compressVideo = (filePath, videoInfo) ->
     width = config.video_compression.target_width
     height = multiplesOf(videoInfo.height / (videoInfo.width / config.video_compression.target_width), 4)
     resolution = "#{width}x#{height}"
-    console.log "output resolution", resolution
     
     outputFile = filePath + ".compressed.mp4"  # output format is 'mp4'
     # command line @see http://tech.ckme.co.jp/ffmpeg.shtml
-    ffmpeg = child_process.spawn("ffmpeg", [
+    ffmpegOptions = [
       "-i", filePath,
       "-b", "#{config.video_compression.bitrate}",  # bitrate as kb/s
       "-r", "#{videoInfo.framerate}",  # framerate to ...
       "-s", resolution,  # resolution to ...
       outputFile
-      ])
+      ]
+    console.log "--- ffmpegOptions\n", JSON.stringify(ffmpegOptions)
+    ffmpeg = child_process.spawn("ffmpeg", ffmpegOptions)
     
     ffmpeg.stdout.on "close", () ->
       # when ffmpeg is done

--- a/src/routes/files.coffee
+++ b/src/routes/files.coffee
@@ -50,13 +50,14 @@ collectVideoInfo = (filePath) ->
       for stream in probeData.streams
         if stream.codec_type isnt "video"
           continue
+        calcFramerate = Math.round(eval(stream.avg_frame_rate) * 100) / 100  # calculate equation with eval. eg. 29.95
         response = 
           file: probeData.file
           width: stream.width
           height: stream.height  
           codec_name: stream.codec_name  # video codec name. eg. h264
           duration: stream.duration  # video length in second
-          framerate: eval(stream.avg_frame_rate)  # calculate equation with eval
+          framerate: calcFramerate
         resolve response
         return
       

--- a/src/routes/files.coffee
+++ b/src/routes/files.coffee
@@ -56,7 +56,7 @@ collectVideoInfo = (filePath) ->
           height: stream.height  
           codec_name: stream.codec_name  # video codec name. eg. h264
           duration: stream.duration  # video length in second
-          framerate: eval(stream.r_frame_rate)  # calculate equation with eval
+          framerate: eval(stream.avg_frame_rate)  # calculate equation with eval
         resolve response
         return
       

--- a/src/routes/files.coffee
+++ b/src/routes/files.coffee
@@ -81,6 +81,9 @@ compressVideo = (filePath, videoInfo) ->
       "-b", "#{config.video_compression.bitrate}",  # bitrate as kb/s
       "-r", "#{videoInfo.framerate}",  # framerate to ...
       "-s", resolution,  # resolution to ...
+      "-vcodec", "libx264",
+      "-vpre", "medium",
+      "-acodec", "copy",
       outputFile
       ]
     console.log "--- ffmpegOptions\n", ffmpegOptions.join " "

--- a/src/routes/files.coffee
+++ b/src/routes/files.coffee
@@ -83,7 +83,7 @@ compressVideo = (filePath, videoInfo) ->
       "-s", resolution,  # resolution to ...
       outputFile
       ]
-    console.log "--- ffmpegOptions\n", JSON.stringify(ffmpegOptions)
+    console.log "--- ffmpegOptions\n", ffmpegOptions.join " "
     ffmpeg = child_process.spawn("ffmpeg", ffmpegOptions)
     
     ffmpeg.stdout.on "close", () ->
@@ -163,7 +163,7 @@ exports.create = (req, res) ->
       .send data
     fs.unlink filePath
     fs.unlink thumbnailFilePath
-    fs.unlink compressVideoPath
+    # fs.unlink compressVideoPath
     return
     
   # エラーレスポンス

--- a/src/routes/files.coffee
+++ b/src/routes/files.coffee
@@ -45,6 +45,7 @@ collectVideoInfo = (filePath) ->
       if err
         reject "node-ffprobe failed. reason: " + err
         
+      console.log "probeData\n", probeData, "\n ---- "
       # find video stream from response and resolve information
       for stream in probeData.streams
         if stream.codec_type isnt "video"


### PR DESCRIPTION
@chae0629 
古いバージョンのffmpegでの圧縮に対応しました。
実行にはnode-ffprobe の導入が必要です。

確認お願いします。